### PR TITLE
Fix WiiM -> HA syncing of group membership

### DIFF
--- a/custom_components/wiim/coordinator.py
+++ b/custom_components/wiim/coordinator.py
@@ -74,13 +74,50 @@ class WiiMCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         # Wrap client in Player (recommended for HA - pywiim manages all state)
         # pywiim 2.1.70+ handles player linking internally via its player registry
+
+        # We need to include player_finder and all_players_finder to enable cross-coordinator group linking.
+        # In pywiim's player/groupsops.py the "Case 2" for device is master but we don't have a group object
+        # short-circuits if there isn't a player_finder callback.
+        # all_players_finder is also included as a final fallback in case the UUID lookup doesn't work for
+        # some reason.
+
         self.player = Player(
             client,
             on_state_changed=self._on_player_state_changed,
+            player_finder=self._player_finder,
+            all_players_finder=self._all_players_finder,
         )
 
         # Use pywiim's PollingStrategy to determine when to poll
         self._polling_strategy = PollingStrategy(self._capabilities) if self._capabilities else PollingStrategy({})
+
+    def _player_finder(self, host_or_uuid: str) -> Player | None:
+        """Find a Player object across all coordinators by host IP or UUID.
+
+        Called by pywiim when it needs to resolve a slave's IP/UUID (from
+        getSlaveList) to an actual Player object for group linking.
+        """
+        from .data import get_all_coordinators
+
+        for coordinator in get_all_coordinators(self.hass):
+            if coordinator is self:
+                continue
+            p = coordinator.player
+            if getattr(p, "host", None) == host_or_uuid:
+                return p
+            if getattr(p, "uuid", None) == host_or_uuid:
+                return p
+        return None
+
+    def _all_players_finder(self) -> list[Player]:
+        """Return all Player objects from every registered coordinator.
+
+        Called by pywiim to infer slave role if e.g. a device is still reporting
+        that it's solo even though it appears in another device's getSlaveList.
+        """
+        from .data import get_all_coordinators
+
+        return [c.player for c in get_all_coordinators(self.hass)]
 
     @callback
     def _on_player_state_changed(self) -> None:

--- a/custom_components/wiim/coordinator.py
+++ b/custom_components/wiim/coordinator.py
@@ -102,11 +102,14 @@ class WiiMCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         for coordinator in get_all_coordinators(self.hass):
             if coordinator is self:
                 continue
-            p = coordinator.player
-            if getattr(p, "host", None) == host_or_uuid:
-                return p
-            if getattr(p, "uuid", None) == host_or_uuid:
-                return p
+            try:
+                p = coordinator.player
+                if getattr(p, "host", None) == host_or_uuid:
+                    return p
+                if getattr(p, "uuid", None) == host_or_uuid:
+                    return p
+            except Exception as err:
+                _LOGGER.warning("Error in player_finder for %s: %s", host_or_uuid, _compact_wiim_error(err))
         return None
 
     def _all_players_finder(self) -> list[Player]:
@@ -117,7 +120,13 @@ class WiiMCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """
         from .data import get_all_coordinators
 
-        return [c.player for c in get_all_coordinators(self.hass)]
+        players = []
+        for c in get_all_coordinators(self.hass):
+            try:
+                players.append(c.player)
+            except Exception as err:
+                _LOGGER.warning("Error in all_players_finder: %s", _compact_wiim_error(err))
+        return players
 
     @callback
     def _on_player_state_changed(self) -> None:

--- a/tests/unit/test_coordinator_core.py
+++ b/tests/unit/test_coordinator_core.py
@@ -1,6 +1,6 @@
 """Core coordinator tests for WiiM - testing pywiim integration."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
 from homeassistant.helpers.update_coordinator import UpdateFailed
@@ -494,6 +494,17 @@ class TestWiiMCoordinator:
         assert result is None
 
     @pytest.mark.asyncio
+    async def test_player_finder_handles_coordinator_error(self, coordinator):
+        """Exceptions raised accessing coordinator.player are caught; method returns None."""
+        bad = MagicMock()
+        type(bad).player = PropertyMock(side_effect=RuntimeError("coordinator not ready"))
+
+        with patch("custom_components.wiim.data.get_all_coordinators", return_value=[coordinator, bad]):
+            result = coordinator._player_finder("192.168.1.101")
+
+        assert result is None
+
+    @pytest.mark.asyncio
     async def test_all_players_finder_includes_self(self, coordinator, mock_player):
         """Returns the calling coordinator's own player (unlike _player_finder, self is not excluded)."""
         with patch("custom_components.wiim.data.get_all_coordinators", return_value=[coordinator]):
@@ -527,4 +538,15 @@ class TestWiiMCoordinator:
             result = coordinator._all_players_finder()
 
         assert result == []
+
+    @pytest.mark.asyncio
+    async def test_all_players_finder_skips_bad_coordinator(self, coordinator, mock_player):
+        """A coordinator whose .player raises is skipped; others are still returned."""
+        bad = MagicMock()
+        type(bad).player = PropertyMock(side_effect=Exception("coordinator not ready"))
+
+        with patch("custom_components.wiim.data.get_all_coordinators", return_value=[coordinator, bad]):
+            result = coordinator._all_players_finder()
+
+        assert result == [mock_player]
 

--- a/tests/unit/test_coordinator_core.py
+++ b/tests/unit/test_coordinator_core.py
@@ -455,3 +455,76 @@ class TestWiiMCoordinator:
         data = await coordinator._async_update_data()
         # Should handle replacement gracefully
         assert data is not None
+
+    @pytest.mark.asyncio
+    async def test_player_finder_by_host(self, coordinator, mock_player):
+        """Test player finder locates another coordinator's player by host IP."""
+        other = MagicMock()
+        other.player = MagicMock(spec=Player)
+        other.player.host = "192.168.1.101"
+        other.player.uuid = "OTHER-UUID-001"
+
+        # get_all_coordinators is a local import inside _player_finder from .data
+        with patch("custom_components.wiim.data.get_all_coordinators", return_value=[coordinator, other]):
+            result = coordinator._player_finder("192.168.1.101")
+
+        assert result is other.player
+
+    @pytest.mark.asyncio
+    async def test_player_finder_by_uuid(self, coordinator, mock_player):
+        """Test player finder locates another coordinator's player by UUID."""
+        other = MagicMock()
+        other.player = MagicMock(spec=Player)
+        other.player.host = "192.168.1.101"
+        other.player.uuid = "OTHER-UUID-ABC"
+
+        with patch("custom_components.wiim.data.get_all_coordinators", return_value=[coordinator, other]):
+            result = coordinator._player_finder("OTHER-UUID-ABC")
+
+        assert result is other.player
+
+    @pytest.mark.asyncio
+    async def test_player_finder_skips_self(self, coordinator, mock_player):
+        """Never return self as the player even when self.player.host matches the search term."""
+        mock_player.host = "192.168.1.100"
+
+        with patch("custom_components.wiim.data.get_all_coordinators", return_value=[coordinator]):
+            result = coordinator._player_finder("192.168.1.100")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_all_players_finder_includes_self(self, coordinator, mock_player):
+        """Returns the calling coordinator's own player (unlike _player_finder, self is not excluded)."""
+        with patch("custom_components.wiim.data.get_all_coordinators", return_value=[coordinator]):
+            result = coordinator._all_players_finder()
+
+        assert result == [mock_player]
+
+    @pytest.mark.asyncio
+    async def test_all_players_finder_returns_all_players(self, coordinator, mock_player):
+        """Returns players from every coordinator."""
+        other1 = MagicMock()
+        other1.player = MagicMock(spec=Player)
+        other2 = MagicMock()
+        other2.player = MagicMock(spec=Player)
+
+        with patch(
+            "custom_components.wiim.data.get_all_coordinators",
+            return_value=[coordinator, other1, other2],
+        ):
+            result = coordinator._all_players_finder()
+
+        assert len(result) == 3
+        assert mock_player in result
+        assert other1.player in result
+        assert other2.player in result
+
+    @pytest.mark.asyncio
+    async def test_all_players_finder_empty(self, coordinator):
+        """Returns an empty list when no coordinators are registered."""
+        with patch("custom_components.wiim.data.get_all_coordinators", return_value=[]):
+            result = coordinator._all_players_finder()
+
+        assert result == []
+


### PR DESCRIPTION
Addresses #197 

If a linked player group is first created from the WiiM side, then no group entity will exist yet. When _find_slave_player (in pywiim's GroupOperations class) is called, it short-circuits because none of the fallback methods for finding the player are provided on the Player object.

This commit defines a player_finder and all_players_finder callback on the integration side so that the new slave player can be identified.

Tested this in my HA installation by joining and unjoining new and existing groups:
* WiiM app: Add player to new group:
  - group_members attribute contains both players
  - group master entity is visible on the coordinator
  - HA join button shows reflects the above
* WiiM app: Add player to existing group:
  - group_members attributes contains all 3 players
  - group master entity is visible on the coordinator
  - HA join button shows reflects the above
* HA: Add player to new group:
  - group_members attribute contains both players
  - group master entity is visible on the coordinator
  - HA join button shows reflects the above
  - WiiM app reflects the above
* HA: Add player to existing group:
  - group_members attributes contains all 3 players
  - group master entity is visible on the coordinator
  - HA join button shows reflects the above
  - WiiM app reflects the above

In all cases, no errors were observed in the logs with debug logging enabled.

# Pull Request

## Description

Brief description of the changes made.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code quality improvement

## Testing

- [ ] I have tested this change locally
- [ ] I have tested with real WiiM devices
- [ ] All existing tests still pass
- [ ] I have added tests for new functionality

## Documentation

- [ ] I have updated relevant documentation
- [ ] I have updated the CHANGELOG.md
- [ ] Example configurations updated (if applicable)

## HACS Compliance

- [ ] Integration files are in `custom_components/wiim/` only
- [ ] No external dependencies added
- [ ] Version number updated in manifest.json (if applicable)
- [ ] hacs.json updated (if metadata changed)

## Integration Quality

- [ ] Code follows Home Assistant integration patterns
- [ ] Async/await used for all I/O operations
- [ ] Proper error handling implemented
- [ ] Entity state management is correct
- [ ] No blocking operations in the main thread

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have checked my code for compatibility with the minimum supported HA version (2024.12.0)

## Breaking Changes

If this is a breaking change, describe what changes users need to make:

- Migration steps required:
- Configuration changes needed:
- Entity changes:

## Additional Notes

Any additional information about the changes.
