### PR TITLE
Clear stale media duration once the live position exceeds it (#251)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Very long tracks showed a stale, incorrect duration** ([Issue #251](https://github.com/mjcumming/wiim/issues/251)). When the device cannot report a duration for a very long track, pywiim retracts it (`raw_dur=None`), but the media player kept republishing the last cached value, so a long track could display as e.g. 41s while the position ran past it. The integration now clears a cached duration once the live position exceeds it, showing an unknown duration instead of an impossible position > duration. The "Impossible media position" log itself originates in pywiim and is unchanged.
+
 ## [1.0.92] - 2026-06-20
 
 ### Fixed

--- a/custom_components/wiim/group_media_player.py
+++ b/custom_components/wiim/group_media_player.py
@@ -115,6 +115,14 @@ class WiiMGroupMediaPlayer(WiiMMediaPlayerMixin, WiimEntity, MediaPlayerEntity):
             self._attr_media_duration = new_duration
         elif current_state == MediaPlayerState.IDLE:
             self._attr_media_duration = None
+        elif (
+            self._attr_media_duration is not None
+            and new_position is not None
+            and new_position > self._attr_media_duration
+        ):
+            # Position has run past the cached duration, so it is stale (a long
+            # track whose duration pywiim retracts to None); clear it. (#251)
+            self._attr_media_duration = None
         # Else: Keep existing duration (don't clear on transient errors during playback)
 
         # Simple Position Update (Robust)

--- a/custom_components/wiim/media_player_base.py
+++ b/custom_components/wiim/media_player_base.py
@@ -108,6 +108,14 @@ class WiiMMediaPlayerMixin:
             self._attr_media_duration = new_duration
         elif current_state == MediaPlayerState.IDLE:
             self._attr_media_duration = None
+        elif (
+            self._attr_media_duration is not None
+            and new_position is not None
+            and new_position > self._attr_media_duration
+        ):
+            # Position has run past the cached duration, so it is stale (a long
+            # track whose duration pywiim retracts to None); clear it. (#251)
+            self._attr_media_duration = None
         # Else: Keep existing duration (don't clear on transient errors during playback)
 
         # Simple Position Update (Robust)

--- a/tests/unit/test_group_media_player.py
+++ b/tests/unit/test_group_media_player.py
@@ -544,6 +544,21 @@ class TestWiiMGroupMediaPlayerMediaInfo:
         entity._update_position_from_coordinator()
         assert entity.media_position == 60
 
+    def test_update_position_clears_stale_duration_when_position_exceeds_it(
+        self, mock_group_master_setup, mock_master_player
+    ):
+        """Clear a cached group duration once the position runs past it (issue #251)."""
+        entity = WiiMGroupMediaPlayer(mock_group_master_setup.coordinator, mock_group_master_setup.config_entry)
+        entity._attr_media_duration = 41  # stale value cached from an earlier read
+
+        mock_master_player.group.play_state = "play"
+        mock_master_player.group.media_position = 304  # past the cached 41
+        mock_master_player.group.media_duration = None  # device cannot report a duration
+
+        entity._update_position_from_coordinator()
+
+        assert entity._attr_media_duration is None
+
 
 class TestWiiMGroupMediaPlayerShuffleRepeat:
     """Test group shuffle and repeat functionality."""

--- a/tests/unit/test_media_player.py
+++ b/tests/unit/test_media_player.py
@@ -1763,6 +1763,45 @@ class TestWiiMMediaPlayerUpdatePosition:
         assert media_player._media_cleared_by_turn_off is False
         assert media_player._attr_state == MediaPlayerState.PLAYING
 
+    def test_update_position_clears_stale_duration_when_position_exceeds_it(
+        self, media_player, mock_coordinator
+    ):
+        """Clear a cached duration once the live position runs past it (issue #251)."""
+        media_player._attr_media_duration = 41  # stale value cached from an earlier read
+
+        player = mock_coordinator.player
+        player.is_slave = False
+        player.group = None
+        player.is_playing = True  # _derive_state_from_player reads is_playing, not play_state
+        player.is_paused = False
+        player.is_buffering = False
+        player.media_position = 304  # live position has run well past the cached 41
+        player.media_duration = None  # device cannot report a duration for the long track
+
+        media_player._update_position_from_coordinator()
+
+        assert media_player._attr_media_position == 304
+        assert media_player._attr_media_duration is None
+
+    def test_update_position_keeps_duration_on_transient_none_within_bounds(
+        self, media_player, mock_coordinator
+    ):
+        """Keep the cached duration when a transient None arrives within bounds."""
+        media_player._attr_media_duration = 180
+
+        player = mock_coordinator.player
+        player.is_slave = False
+        player.group = None
+        player.is_playing = True  # _derive_state_from_player reads is_playing, not play_state
+        player.is_paused = False
+        player.is_buffering = False
+        player.media_position = 60  # still within the cached duration
+        player.media_duration = None  # transient miss
+
+        media_player._update_position_from_coordinator()
+
+        assert media_player._attr_media_duration == 180
+
 
 class TestWiiMMediaPlayerServiceHandlers:
     """Test service handler methods."""


### PR DESCRIPTION
# Pull Request

## Description

Addresses #251.

When the device cannot report a duration for a very long track, pywiim retracts it (`raw_dur=None`). `_update_position_from_coordinator` keeps the last cached `_attr_media_duration` during playback to ride out transient gaps, so the integration kept republishing a stale value (41s in the report) while the live position climbed past it, producing a wrong duration and an impossible position > duration.

The fix clears the cached duration once the live position has run strictly past it, in both the standalone (`media_player_base.py`) and group (`group_media_player.py`) `_update_position_from_coordinator`. The existing transient-tolerance is preserved: a missing duration with the position still within the cached value keeps it. This is entity-side state management, not duration logic (pywiim stays the source of truth), in line with ADR-0001. The "Impossible media position" warning is logged inside pywiim and is unchanged here.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code quality improvement

## Testing

- [x] I have tested this change locally
- [ ] I have tested with real WiiM devices
- [x] All existing tests still pass
- [x] I have added tests for new functionality

Added failing-first regression tests (ADR-0003): a clear case and a keep-within-bounds case in `tests/unit/test_media_player.py`, and the group clear case in `tests/unit/test_group_media_player.py`. Confirmed they fail without the fix (the stale duration stays cached) and pass with it. Full unit suite via `make test-quick`: 585 passed, 23 skipped (82.97% coverage). I do not have a WiiM device, so the real-device box is unchecked; the reporter on #251 has the exact repro (an 11h local mp3) and could confirm a build.

## Documentation

- [ ] I have updated relevant documentation
- [x] I have updated the CHANGELOG.md
- [ ] Example configurations updated (if applicable)

## HACS Compliance

- [x] Integration files are in `custom_components/wiim/` only
- [x] No external dependencies added
- [ ] Version number updated in manifest.json (if applicable)
- [ ] hacs.json updated (if metadata changed)

## Integration Quality

- [x] Code follows Home Assistant integration patterns
- [x] Async/await used for all I/O operations
- [x] Proper error handling implemented
- [x] Entity state management is correct
- [x] No blocking operations in the main thread

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code for compatibility with the minimum supported HA version (2024.12.0)

## Breaking Changes

None. Behaviour is unchanged when the duration is valid, when the state is idle, or when a transient missing duration arrives with the position still within the cached value.

## Additional Notes

The "Impossible media position" log and the possible OOM mentioned in #251 originate outside this change (pywiim, or a separate cause) and are not addressed here.
